### PR TITLE
xdebug configuration and image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM php:7.2-fpm-alpine
 LABEL maintainer="jonathan <chc.jonathan.guo@outlook.com>"
-ARG xdebug_remote_host=10.254.254.254
 
 WORKDIR /app
 
@@ -67,17 +66,17 @@ RUN docker-php-ext-configure gd \
 
 # Install PECL extensions
 # see http://stackoverflow.com/a/8154466/291573) for usage of `printf`
-RUN printf "\n" | pecl install xdebug-2.6.0 && \
+RUN pecl install xdebug && \
     pecl install grpc && \
     docker-php-ext-enable xdebug grpc && \
     echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     echo "xdebug.default_enable=off" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    echo "xdebug.remote_host=$xdebug_remote_host" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    echo "xdebug.remote_host=docker.for.mac.localhost" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     echo "xdebug.remote_port=9005" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     echo "xdebug.remote_connect_back=off" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    echo "xdebug.remote_log=\"/tmp/xdebug.log\"" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+    echo "xdebug.remote_log=/tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 ADD nginx/nginx.conf /etc/nginx/nginx.conf
 ADD supervisor/supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
**Update xdebug configuration**
- use `docker.for.mac.localhost` as xdebug remote_host
- remove fixed xdebug version during installation

**Make image size smaller**
 - from 481MB to 236MB
- change `composer` installation command